### PR TITLE
Update client ident docs

### DIFF
--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -17,21 +17,15 @@ The API is defined using the RESTful principles.
 
 ## <a name="security_model"></a> Security Model
 
-### Communication Security
-
 The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the 
 backend). The API currently uses TLS 1.2. It is the integrator's responsibility to plan for an upgrade to TLS 1.3, when
-TLS 1.2 is deprecated. 
-
-### Integrator Authorization
-
-The MobilePay API Gateway is ensuring the authentication of all PoS API requests. 
-In order to be granted access to the MobilePay PoS API each integrator/vendor will have to enroll their clients as a client (called App) in our API Gateway Developer Portal (see [Client Identification](api_principles#client_identification) for more information).
-
-Creating an app in MobilePay Developer Portal will create a client ID that should be used in all calls to the MobilePay PoS API in the following way:
+TLS 1.2 is deprecated. The MobilePay PoS V10 API uses access tokens to authenticate calls from clients. After [obtaining
+an access token](pos_integratorauthentication), the client must send the token in an Authorization header along with the
+`client_id` in the `x-ibm-client-id` header in all calls to the MobilePay PoS API.
 
 ````
---header 'x-ibm-client-id: 80e0075c-d0b5-4b74-a466-ecaca65234b0'
+--header 'x-ibm-client-id: {client_id}'
+--header 'Authorization: Bearer {access_token}'
 ````
 
 ## <a name="client_identification"></a> Client Identification

--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -31,17 +31,17 @@ In order to be granted access to the MobilePay PoS API each integrator/vendor wi
 Creating an app in MobilePay Developer Portal will create a client ID that should be used in all calls to the MobilePay PoS API in the following way:
 
 ````
---header 'X-IBM-Client-Id: 80e0075c-d0b5-4b74-a466-ecaca65234b0'
+--header 'x-ibm-client-id: 80e0075c-d0b5-4b74-a466-ecaca65234b0'
 ````
 
 ## <a name="client_identification"></a> Client Identification
 
 All calls to the MobilePay PoS V10 API must include the following two headers `X-MobilePay-Client-System-Name` and
-`X-MobilePay-Client-System-Version` to identify the client system and verify that the given system has been [certified](api_principles#self_certification).
-The Client Name (`X-MobilePay-Client-System-Name`) is a suitable name used for the 
+`x-mobilepay-client-system-version` to identify the client system and verify that the given system has been [certified](api_principles#self_certification).
+The Client Name (`x-mobilepay-client-system-name`) is a suitable name used for the 
 client, preferably the name that the integrator uses in their own communication. This way support communication 
 between merchant, integrator and MobilePay uses the same name which should aid in removing confusion in the support 
-situation. The Client Version (`X-MobilePay-Client-System-Version`) is a 3 dimensional number Major.Minor.Build. It 
+situation. The Client Version (`x-mobilepay-client-system-version`) is a 3 dimensional number Major.Minor.Build. It 
 is recommended that when the client software is updated, the client version is updated accordingly. 
 The client version will be used by MobilePay to block versions of clients that are not certified 
 and/or are misbehaving. An example of misbehavior is spamming irrelevant HTTP calls that endanger fast 
@@ -60,8 +60,8 @@ Certification requirements in regard to changes to Client Name and Client Versio
 The Client Name and Client Version should be added in all calls as shown below.
 
 ````
---header 'X-MobilePay-Client-System-Name: MobilePay Pos Client Reference Implementation'
---header 'X-MobilePay-Client-System-Version: 2.1.1'
+--header 'x-mobilepay-client-system-name: MobilePay Pos Client Reference Implementation'
+--header 'x-mobilepay-client-system-version: 2.1.1'
 ````
 
 ## <a name="api_responses"></a> API Responses

--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -20,8 +20,8 @@ The API is defined using the RESTful principles.
 The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the 
 backend). The API currently uses TLS 1.2. It is the integrator's responsibility to plan for an upgrade to TLS 1.3, when
 TLS 1.2 is deprecated. The MobilePay PoS V10 API uses access tokens to authenticate calls from clients. After [obtaining
-an access token](pos_integratorauthentication), the client must send the token in an Authorization header along with the
-`client_id` in the `x-ibm-client-id` header in all calls to the MobilePay PoS API.
+an access token](pos_integratorauthentication), the client must send the access token in an Authorization header along with the
+`client_id` as follows in all calls to the MobilePay PoS API:
 
 ````
 --header 'x-ibm-client-id: {client_id}'

--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -21,7 +21,7 @@ The MobilePay PoS V10 API uses TLS for communication security and data integrity
 backend). The API currently uses TLS 1.2. It is the integrator's responsibility to plan for an upgrade to TLS 1.3, when
 TLS 1.2 is deprecated. The MobilePay PoS V10 API uses access tokens to authenticate calls from clients. After [obtaining
 an access token](pos_integratorauthentication), the client must send the access token in an Authorization header along with the
-`client_id` as follows in all calls to the MobilePay PoS API:
+`client_id` as follows in all calls to the MobilePay PoS V10 API:
 
 ````
 --header 'x-ibm-client-id: {client_id}'

--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -36,7 +36,7 @@ Creating an app in MobilePay Developer Portal will create a client ID that shoul
 
 ## <a name="client_identification"></a> Client Identification
 
-All calls to the MobilePay PoS V10 API must include the following two headers `X-MobilePay-Client-System-Name` and
+All calls to the MobilePay PoS V10 API must include the following two headers `x-mobilepay-client-system-name` and
 `x-mobilepay-client-system-version` to identify the client system and verify that the given system has been [certified](api_principles#self_certification).
 The Client Name (`x-mobilepay-client-system-name`) is a suitable name used for the 
 client, preferably the name that the integrator uses in their own communication. This way support communication 

--- a/docs/api_principles.md
+++ b/docs/api_principles.md
@@ -28,14 +28,11 @@ an access token](pos_integratorauthentication), the client must send the token i
 --header 'Authorization: Bearer {access_token}'
 ````
 
-## <a name="client_identification"></a> Client Identification
+## <a name="client_identification"></a> Client Versioning
 
-All calls to the MobilePay PoS V10 API must include the following two headers `x-mobilepay-client-system-name` and
-`x-mobilepay-client-system-version` to identify the client system and verify that the given system has been [certified](api_principles#self_certification).
-The Client Name (`x-mobilepay-client-system-name`) is a suitable name used for the 
-client, preferably the name that the integrator uses in their own communication. This way support communication 
-between merchant, integrator and MobilePay uses the same name which should aid in removing confusion in the support 
-situation. The Client Version (`x-mobilepay-client-system-version`) is a 3 dimensional number Major.Minor.Build. It 
+In addition to the access token which identifies the client calling the MobilePay PoS V10 API, all calls must also
+include the `x-mobilepay-client-system-version` header to identify the version of the client software and verifythat the given system has been [certified](api_principles#self_certification).
+The Client Version (`x-mobilepay-client-system-version`) is a 3 dimensional number Major.Minor.Build. It 
 is recommended that when the client software is updated, the client version is updated accordingly. 
 The client version will be used by MobilePay to block versions of clients that are not certified 
 and/or are misbehaving. An example of misbehavior is spamming irrelevant HTTP calls that endanger fast 
@@ -46,15 +43,14 @@ The three parts of the Client Version is defined as described below.
 * Minor version represents minor changes to the client version, changes that introduces new features or a change in the way internal logic is handled. Minor version changes are perhaps not communicated to merchants. A minor change requires recertification.
 * Build version represents a new build of the client, including minor bug-fixes and changes of the lowest magnitude. A new build version does not require recertification.
 
-Certification requirements in regard to changes to Client Name and Client Version are the following
+Certification requirements in regard to changes to Client Version are as follows
 
-* Changes in Client Name, major version or minor version require a new Certification.
+* Changes in major version or minor version require a new Certification.
 * Changes in Build version do not require a new Certification.
 
-The Client Name and Client Version should be added in all calls as shown below.
+The Client Version should be added in all calls as shown below.
 
 ````
---header 'x-mobilepay-client-system-name: MobilePay Pos Client Reference Implementation'
 --header 'x-mobilepay-client-system-version: 2.1.1'
 ````
 

--- a/docs/input_formats.md
+++ b/docs/input_formats.md
@@ -7,11 +7,11 @@ For more information about the http headers, see [API principles](api_principles
 
 | Name | Format      | Description |
 |------|-------------|-------------|
-| `X-IBM-Client-Id` | Guid | Identifies an application created through MobilePay Developer Portal. |
-| `X-MobilePay-Merchant-VAT-Number` | Valid VAT number:<br>IsoCountryCodeVATNumber<br>Example: DK12345678 | Identifies the merchant the integrator is calling on behalf of |
-| `X-MobilePay-Client-System-Name` | String with at most 36 valid characters | Identifies the [integrator system](api_principles#client_identification) calling the API. |
-| `X-MobilePay-Client-System-Version` | Valid Client-Version:<br>Major.Minor.Build<br>Example: 1.2.1 | Identifies the [version of the integrator system](api_principles#client_identification) calling the API. |
-| `X-MobilePay-Idempotency-Key` | String with at most 36 valid characters | Used to allow calls to be [safely retried](api_principles#error_handling) in case of errors. |
+| `x-ibm-client-id` | Guid | Identifies an application created through MobilePay Developer Portal. |
+| `x-mobilepay-merchant-vat-number` | Valid VAT number:<br>IsoCountryCodeVATNumber<br>Example: DK12345678 | Identifies the merchant the integrator is calling on behalf of |
+| `x-mobilepay-client-system-name` | String with at most 36 valid characters | Identifies the [integrator system](api_principles#client_identification) calling the API. |
+| `x-mobilepay-client-system-version` | Valid Client-Version:<br>Major.Minor.Build<br>Example: 1.2.1 | Identifies the [version of the integrator system](api_principles#client_identification) calling the API. |
+| `x-mobilepay-idempotency-key` | String with at most 36 valid characters | Used to allow calls to be [safely retried](api_principles#error_handling) in case of errors. |
 
 ## Brands
 For more information about brands, see [PoS Management](pos_management).

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -24,15 +24,15 @@ The PoS V10 API uses access tokens to authenticate calls from integrator clients
 
 ### **Credentials Flow:**
 
-The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token.
+The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token. The Credentials Flow is illustrated in the diagram below.
 
 [![](assets/images/clientcredentialsdiagram.png)](assets/images/possekvensdiagram.png)
 
- 1. The client app authenticates with the Authorization Server using its Client ID and Client Secret using the token endpoint.
+ 1. The client app authenticates with the Authorization Server using its `client_id` and `client_secret` using the token endpoint.
  2. The Authorization Server validates the `client_id` and `client_secret`.
  3. The Authorization Server responds with an `access_token`.
  4. The Client application can use the `access_token` to call the PoS V10 API.
- 5. The API responds with requested data.
+ 5. The PoS V10 API responds.
 
 [![](assets/images/possekvensdiagram.png)](assets/images/possekvensdiagram.png)
 

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -1,7 +1,7 @@
 
 The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the backend) and uses access tokens to authenticate clients. The guide below describe the steps to onboard an client and generate access tokens to authenticate the client. 
 
-# **Steps to Onboard a PoS client**
+# **Onboarding a PoS client**
 
 1. **Read API documentation.** You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
 
@@ -15,30 +15,23 @@ The MobilePay PoS V10 API uses TLS for communication security and data integrity
 -  Integrator Authentication 
  
  5.  **Receive OAuth Client Credentials via zip file.** The Client Credentials will be used when calling the token endpoint (described below) to generate an access token. The zip file will be sent via e-mail. The zip file is locked with a password. DeveloperSupport will provide the password via text message to ensure the password protected file and the password is not transmitted together.
- 
+
 Now you are ready to move on to the authentication section below.  
 
 # **Integrator Authentication:**
 
-In order for Integrators to be able to use MobilePay APIs, first they'll have to obtain an `access_token` from the Integrator Authentication service. This way, MobilePay knows who is calling our service. 
-
-  **Environments:**
-The following URL are the environment routes for the Integrator Authentication API
-
- - SandBox: `https://api.sandbox.mobilepay.dk/integrator-authentication`
- - Production: `https://api.mobilepay.dk/integrator-authentication`
+The PoS V10 API uses access tokens to authenticate calls from clients. In order for a client to use the PoS V10 API, it must first obtain an access token using the Integrator Authentication API. The access tokens used in the PoS V10 solution identifies both a client and the integrator that developed the client and optionally the merchant on which the client is calling on behalf of. 
 
 ### **Credentials Flow:**
 
-The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the  flow supported is the Client Credentials grant type. Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), in which Integrators pass along their `client_id` and `client_secret` to authenticate themselves and get a token.
+The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), Integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token.
 
 [![](assets/images/clientcredentialsdiagram.png)](assets/images/possekvensdiagram.png)
 
-
- 1. The client app authenticates with the Authorization Server using its Client ID and Client Secret /token endpoint
+ 1. The client app authenticates with the Authorization Server using its Client ID and Client Secret using the token endpoint.
  2. The Authorization Server validates the `client_id` and `client_secret`.
  3. The Authorization Server responds with an `access_token`.
- 4. The Client application can use the `access_token` to call the API
+ 4. The Client application can use the `access_token` to call the PoS V10 API.
  5. The API responds with requested data.
 
 [![](assets/images/possekvensdiagram.png)](assets/images/possekvensdiagram.png)
@@ -47,7 +40,6 @@ The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specific
 
 This document does not include a compete specification of the endpoints, responses and response codes. This information can be found in the [APIs section](https://developer.mobilepay.dk/product) of the Developer Portal.
  
-
 ## `POST /connect/token`
 
 The token endpoint is used when requesting an `access token` for an onboarded integrator client.
@@ -56,9 +48,9 @@ Headers:
 
  - **``Content-Type``**: x-www-urlencoded
  - **``x-ibm-client-id``**: Client_Id supplied upon certification.
- - **``Authorization``**: Basic ({CLIENT_ID}:{CLIENT_SECRET}).toBase64EncodedString().
+ - **``Authorization``**: Basic ({client_id}:{client_secret}).toBase64EncodedString().
 
-The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail 
+The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail
 
  
 | Parameter | Value  | Description  |
@@ -66,9 +58,7 @@ The OAuth `client_id`and `client_secret` will be sent to the integrator in a clo
 | grant_type    | client_credentials     | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
 | merchant_vat     | DK12345678 or FI12345678       | VAT Number of the Merchant the integrator is integrating on behalf. It will be applied to the JWT access token, if supplied. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits.      |
 
-Example of response body from SandProd environment:
-
-Response Body
+Example of response body from SandBox environment:
 
 ```
 {
@@ -84,7 +74,7 @@ Response Body
 You might encounter the following status codes :
 
 * `200 - OK`  
-* `401 - Unauthorized` , if the client is not authorized/authenticated through the API Gateway
+* `401 - Unauthorized` if the client is not authorized/authenticated through the API Gateway
 
 
 ### cURL example:
@@ -97,3 +87,9 @@ curl --location --request POST 'https://api.sandbox.mobilepay.dk/integrator-auth
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'merchant_vat=DK12345678'
 ```
+
+ **Environments:**
+The following URL are the environment routes for the Integrator Authentication API
+
+ - SandBox: `https://api.sandbox.mobilepay.dk/integrator-authentication`
+ - Production: `https://api.mobilepay.dk/integrator-authentication`

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -1,7 +1,7 @@
 
-The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the backend) and uses access tokens to authenticate clients. The guide below describe the steps to onboard an client and generate access tokens to authenticate the client. 
+The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the backend) and uses access tokens to authenticate integrator clients. The guide below describe the steps to onboard an integrator client and generate access tokens to authenticate the integrator client. 
 
-# **Onboarding a PoS client**
+# **Onboarding a PoS integrator client**
 
 1. **Read API documentation.** You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
 
@@ -20,11 +20,11 @@ Now you are ready to move on to the authentication section below.
 
 # **Integrator Authentication:**
 
-The PoS V10 API uses access tokens to authenticate calls from clients. In order for a client to use the PoS V10 API, it must first obtain an access token using the Integrator Authentication API. The access tokens used in the PoS V10 solution identifies both a client and the integrator that developed the client and optionally the merchant on which the client is calling on behalf of. 
+The PoS V10 API uses access tokens to authenticate calls from integrator clients. In order for an integrator client to use the PoS V10 API, it must first obtain an access token using the Integrator Authentication API. The access tokens used in the PoS V10 solution identifies both an integrator client and the integrator and may optionally identify the merchant on which the client is calling on behalf of. 
 
 ### **Credentials Flow:**
 
-The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), Integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token.
+The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token.
 
 [![](assets/images/clientcredentialsdiagram.png)](assets/images/possekvensdiagram.png)
 
@@ -36,13 +36,11 @@ The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specific
 
 [![](assets/images/possekvensdiagram.png)](assets/images/possekvensdiagram.png)
 
-# **Endpoint description:**
+# **Obtaining an access token:**
 
-This document does not include a compete specification of the endpoints, responses and response codes. This information can be found in the [APIs section](https://developer.mobilepay.dk/product) of the Developer Portal.
+This document only describes the token endpoint used to request an access token. A complete specification of the endpoints, responses and response codes for the Integrator Authentication API can be found in the [APIs section](https://developer.mobilepay.dk/product) of the Developer Portal.
  
-## `POST /connect/token`
-
-The token endpoint is used when requesting an `access token` for an onboarded integrator client.
+The token endpoint (`POST /connect/token`) is used when requesting an access token for an onboarded integrator client.
 
 Headers:
 
@@ -59,7 +57,6 @@ The OAuth `client_id`and `client_secret` will be sent to the integrator in a clo
 | merchant_vat     | DK12345678 or FI12345678       | VAT Number of the Merchant the integrator is integrating on behalf. It will be applied to the JWT access token, if supplied. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits.      |
 
 Example of response body from SandBox environment:
-
 ```
 {
     "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
@@ -75,7 +72,6 @@ You might encounter the following status codes :
 
 * `200 - OK`  
 * `401 - Unauthorized` if the client is not authorized/authenticated through the API Gateway
-
 
 ### cURL example:
 

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -85,7 +85,7 @@ curl --location --request POST 'https://api.sandbox.mobilepay.dk/integrator-auth
 ```
 
  **Environments:**
-The following URL are the environment routes for the Integrator Authentication API
+The following URLs are the environment routes for the Integrator Authentication API
 
  - SandBox: `https://api.sandbox.mobilepay.dk/integrator-authentication`
  - Production: `https://api.mobilepay.dk/integrator-authentication`

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -1,18 +1,20 @@
-# **Steps to Authenticate PoS**
 
+The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the backend) and uses access tokens to authenticate clients. The guide below describe the steps to onboard an client and generate access tokens to authenticate the client. 
 
-1. **Read API documentation**. You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
+# **Steps to Onboard a PoS client**
 
-2.  **Log-in** Go to  [Sandbox developer portal](https://sandbox-developer.mobilepay.dk/ ) and log in with your credentials.
+1. **Read API documentation.** You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
 
- 3.  **Create app** - My Apps > Create new App to register a new application.   You need to supply the `x-ibm-client-id`  when calling the api. You should always store the `x-ibm-client-id` in a secure location, and never reveal it publicly.  More details about the usage of `x-ibm-client-id` below in the authentication section. 
+2.  **Log-in on the developer portal.** Go to [Sandbox developer portal](https://sandbox-developer.mobilepay.dk/) and log in with your credentials.
 
-4.  **Subscribe to APIs.**  To implement MobilePay PoS, go to  [APIs](https://sandbox-developer.mobilepay.dk/product)  and subscribe to the following APIs:
+ 3.  **Create an app in the developer portal.** - My Apps > Create new App to register a new application.   You need to supply the `x-ibm-client-id`  when calling the API. You should always store the `x-ibm-client-id` in a secure location, and never reveal it publicly.  More details about the usage of `x-ibm-client-id` below in the authentication section. 
+
+4.  **Subscribe the app to APIs.**  Go to [APIs](https://sandbox-developer.mobilepay.dk/product) and subscribe to the following APIs:
 -  PoS for Integrators  
 -  PoS User simulation for Integrators
 -  Integrator Authentication 
  
- 5.  **Receive OAuth Client Credentials via zip file.** The Client Credentials are to be used when calling the token endpoint. The zip file will be sent via e-mail. The zip file is locked with a password. DeveloperSupport will provide the password via text message, due to security reasons.
+ 5.  **Receive OAuth Client Credentials via zip file.** The Client Credentials will be used when calling the token endpoint (described below) to generate an access token. The zip file will be sent via e-mail. The zip file is locked with a password. DeveloperSupport will provide the password via text message to ensure the password protected file and the password is not transmitted together.
  
 Now you are ready to move on to the authentication section below.  
 
@@ -27,7 +29,6 @@ The following URL are the environment routes for the Integrator Authentication A
  - Production: `https://api.mobilepay.dk/integrator-authentication`
 
 ### **Credentials Flow:**
-
 
 The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the  flow supported is the Client Credentials grant type. Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), in which Integrators pass along their `client_id` and `client_secret` to authenticate themselves and get a token.
 
@@ -44,13 +45,12 @@ The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specific
 
 # **Endpoint description:**
 
-This document does not include a compete specification of the endpoints, responses and response codes. This information can be found in the [APIs section](https://developer.mobilepay.dk/product). of the Developer Portal.
-
+This document does not include a compete specification of the endpoints, responses and response codes. This information can be found in the [APIs section](https://developer.mobilepay.dk/product) of the Developer Portal.
  
 
 ## `POST /connect/token`
 
-The token endpoint is when requesting an `access token` for an onboarded integrator client.
+The token endpoint is used when requesting an `access token` for an onboarded integrator client.
 
 Headers:
 
@@ -58,13 +58,13 @@ Headers:
  - **``x-ibm-client-id``**: Client_Id supplied upon certification.
  - **``Authorization``**: Basic ({CLIENT_ID}:{CLIENT_SECRET}).toBase64EncodedString().
 
-The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from developer@mobilepay.dk to integrators e-mail 
+The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail 
 
  
 | Parameter | Value  | Description  |
 | :---         |     :---:      |          :---:  |
 | grant_type    | client_credentials     | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
-| merchant_vat     | DK12345678 or FI12345678       | VAT Number of the Merchant the integrator is integrating on behalf. It will be applied to the JWT access token, if supplied. We support FI and DK vat numbers. The vat number consists of country prefix (either FI or DK) and 8 digits.      |
+| merchant_vat     | DK12345678 or FI12345678       | VAT Number of the Merchant the integrator is integrating on behalf. It will be applied to the JWT access token, if supplied. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits.      |
 
 Example of response body from SandProd environment:
 
@@ -83,10 +83,8 @@ Response Body
 
 You might encounter the following status codes :
 
-1. `200 - OK`  
- 
-
-2. `401 - Unauthorized` , if the client is not authorized/authenticated through the API Gateway
+* `200 - OK`  
+* `401 - Unauthorized` , if the client is not authorized/authenticated through the API Gateway
 
 
 ### cURL example:

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -45,12 +45,12 @@ headers must be set:
  - **``x-ibm-client-id``**: `client_id`
  - **``Authorization``**: Basic (`client_id`:`client_secret`).toBase64EncodedString().
 
-The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail (step 5 in the [Client onboarding guide](pos_integratorauthentication#client_onboarding).
+The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail (step 5 in the [Client onboarding guide](pos_integratorauthentication#client_onboarding)).
 
-In addition, the `grant_type` must be set and a `merchant_vat` parameter may optionally be set as described below:
+In addition, the `grant_type` parameter must be set and a `merchant_vat` parameter may optionally be set as described below:
  
 | Parameter | Value  | Description  |
-| :---         |     :---:      |          :---:  |
+| :---         |     :---:      | :---  |
 | `grant_type` | client_credentials | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
 | `merchant_vat` | DK12345678 or FI12345678 | VAT number of the merchant the integrator client is calling on behalf of. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits. |
 

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -3,11 +3,11 @@ The MobilePay PoS V10 API uses TLS for communication security and data integrity
 
 # <a name="client_onboarding"></a>**Onboarding a PoS integrator client**
 
-1. **Read API documentation.** You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
+1. **Read API documentation.** You will find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
 
 2.  **Log-in on the developer portal.** Go to [Sandbox developer portal](https://sandbox-developer.mobilepay.dk/) and log in with your credentials.
 
- 3.  **Create an app in the developer portal.** - My Apps > Create new App to register a new application.   You need to supply the `x-ibm-client-id`  when calling the API. You should always store the `x-ibm-client-id` in a secure location, and never reveal it publicly.  More details about the usage of `x-ibm-client-id` below in the authentication section. 
+ 3.  **Create an app in the developer portal.** Go to My Apps > Create new App to register a new application. You need to supply the `x-ibm-client-id` when calling APIs. You should always store the `x-ibm-client-id` in a secure location, and never reveal it publicly.  More details about the usage of `x-ibm-client-id` below in the authentication section. 
 
 4.  **Subscribe the app to APIs.**  Go to [APIs](https://sandbox-developer.mobilepay.dk/product) and subscribe to the following APIs:
 -  PoS for Integrators  

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -52,7 +52,7 @@ In addition, the `grant_type` parameter must be set and a `merchant_vat` paramet
 | Parameter | Value  | Description  |
 | :---         |     :---:      | :---  |
 | `grant_type` | client_credentials | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
-| `merchant_vat` | DK12345678 or FI12345678 | VAT number of the merchant the integrator client is calling on behalf of. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits. |
+| `merchant_vat` | DK12345678 or FI12345678 | VAT number of the merchant the integrator client is calling on behalf of. The VAT number consists of country prefix (either FI or DK) and 8 digits. |
 
 If the `merchant_vat` parameter is supplied, the VAT number will be added as a claim on the access token, and it will only be possible to use the access token to perform calls on behalf of the given merchant. If it is not supplied, the access token will not be restricted to a fixed merchant. Instead, clients will have to include a header on all calls to the PoS V10 API that includes the VAT number of the merchant the client is acting on behalf of, for the given call. 
 

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -26,15 +26,13 @@ The PoS V10 API uses access tokens to authenticate calls from integrator clients
 
 The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specification. By following the OpenID Connect protocol, MobilePay makes it easy for integrators to integrate with MobilePay. Currently, the flow supported is the Client Credentials grant type. In the Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), integrators pass along their `client_id` and `client_secret` (received in Step 5 above) to authenticate themselves and obtain an access token. The Credentials Flow is illustrated in the diagram below.
 
-[![](assets/images/clientcredentialsdiagram.png)](assets/images/possekvensdiagram.png)
+[![](assets/images/possekvensdiagram.png)](assets/images/possekvensdiagram.png)
 
  1. The client app authenticates with the Authorization Server using its `client_id` and `client_secret` using the token endpoint.
  2. The Authorization Server validates the `client_id` and `client_secret`.
  3. The Authorization Server responds with an `access_token`.
  4. The Client application can use the `access_token` to call the PoS V10 API.
  5. The PoS V10 API responds.
-
-[![](assets/images/possekvensdiagram.png)](assets/images/possekvensdiagram.png)
 
 # **Obtaining an access token:**
 

--- a/docs/pos_integratorauthentication.md
+++ b/docs/pos_integratorauthentication.md
@@ -1,7 +1,7 @@
 
 The MobilePay PoS V10 API uses TLS for communication security and data integrity (secure channel between the client and the backend) and uses access tokens to authenticate integrator clients. The guide below describe the steps to onboard an integrator client and generate access tokens to authenticate the integrator client. 
 
-# **Onboarding a PoS integrator client**
+# <a name="client_onboarding"></a>**Onboarding a PoS integrator client**
 
 1. **Read API documentation.** You'll find it in the  [APIs menu](https://developer.mobilepay.dk/product).  
 
@@ -38,21 +38,23 @@ The Integrator Authentication solution is based on the OpenID/OAuth 2.0 specific
 
 This document only describes the token endpoint used to request an access token. A complete specification of the endpoints, responses and response codes for the Integrator Authentication API can be found in the [APIs section](https://developer.mobilepay.dk/product) of the Developer Portal.
  
-The token endpoint (`POST /connect/token`) is used when requesting an access token for an onboarded integrator client.
-
-Headers:
+The token endpoint (`POST /connect/token`) is used when requesting an access token for an onboarded integrator client. The following
+headers must be set:
 
  - **``Content-Type``**: x-www-urlencoded
- - **``x-ibm-client-id``**: Client_Id supplied upon certification.
- - **``Authorization``**: Basic ({client_id}:{client_secret}).toBase64EncodedString().
+ - **``x-ibm-client-id``**: `client_id`
+ - **``Authorization``**: Basic (`client_id`:`client_secret`).toBase64EncodedString().
 
-The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail
+The OAuth `client_id`and `client_secret` will be sent to the integrator in a closed zip file from [developer@mobilepay.dk](mailto:developer@mobilepay.dk) to integrators e-mail (step 5 in the [Client onboarding guide](pos_integratorauthentication#client_onboarding).
 
+In addition, the `grant_type` must be set and a `merchant_vat` parameter may optionally be set as described below:
  
 | Parameter | Value  | Description  |
 | :---         |     :---:      |          :---:  |
-| grant_type    | client_credentials     | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
-| merchant_vat     | DK12345678 or FI12345678       | VAT Number of the Merchant the integrator is integrating on behalf. It will be applied to the JWT access token, if supplied. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits.      |
+| `grant_type` | client_credentials | The Client Credentials grant type is used by clients to obtain an `access_token` outside of the context of a user.     |
+| `merchant_vat` | DK12345678 or FI12345678 | VAT number of the merchant the integrator client is calling on behalf of. The PoS V10 API supports FI and DK VAT numbers. The VAT number consists of country prefix (either FI or DK) and 8 digits. |
+
+If the `merchant_vat` parameter is supplied, the VAT number will be added as a claim on the access token, and it will only be possible to use the access token to perform calls on behalf of the given merchant. If it is not supplied, the access token will not be restricted to a fixed merchant. Instead, clients will have to include a header on all calls to the PoS V10 API that includes the VAT number of the merchant the client is acting on behalf of, for the given call. 
 
 Example of response body from SandBox environment:
 ```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,6 +4,14 @@ The Point of Sale API V10 will be in production **Q2 2020**. It will be released
 
 ## Changelog
 
+### 2020-03-27
+
+- Dropped the `x-ibm-client-system-name` header and modified the [API principles](api_principles) page to explain how the `x-ibm-client-system-version` header will be used for client versioning.
+
+- Renamed all `X-IBM-*` and `X-MobilePay-*` headers to be lowercase in the documentation (the actual headers are case-insensitive).
+
+---
+
 ### 2020-03-26
 
 - Renamed `vat_number` parameter to `merchant_vat` for [Authentication](pos_integratorauthentication) endpoint and changed the format to remove the dash between country code and VAT (e.g., "DK12345678" instead of "DK-12345678"). 


### PR DESCRIPTION
Integrated some of the text regarding security model & client identification into the integrator authentication text. Dropped the 'x-ibm-client-system-name' header as that information will be included in the access token and changed the section on client identification into a section on client versioning.