### PR TITLE
Introduce error code for when a PaymentPoint cannot afford a refund

### DIFF
--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on available store balance |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Cannot refund ''amount'' as it exceeds the current available balance on the store |
 
 </details><br>
 

--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Cannot refund ``Amount`` as it exceeds the current available balance on the store |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Cannot refund ``Amount`` as it exceeds the available balance on the store |
 
 </details><br>
 

--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on store balance |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on available store balance |
 
 </details><br>
 

--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on payment point |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on store balance |
 
 </details><br>
 

--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Cannot refund ''amount'' as it exceeds the current available balance on the store |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Cannot refund ``Amount`` as it exceeds the current available balance on the store |
 
 </details><br>
 

--- a/docs/endpoint_errors.md
+++ b/docs/endpoint_errors.md
@@ -168,7 +168,7 @@ This page contains information regarding all the non-successful status-codes and
 |------------|-------------|-------------|
 | 400 | 1102`` `` <br> 1114`` `` <br> 1162`` `` <br> 1163`` `` <br> 1164`` `` | Invalid ``Amount`` <br> Invalid ``RefundOrderId`` <br> Invalid ``x-mobilepay-idempotency-key`` header <br> Duplicated ``x-mobilepay-idempotency-key`` header <br> Missing ``x-mobilepay-idempotency-key`` header |
 | 403 | 1401 | Cannot refund payments created by a different integrator |
-| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high |
+| 409 | 1001 <br> 1306`` `` <br> <br> 1354 <br> 1365 <br> 1366 <br> 1367 <br> 1368 | Payment not found <br> ``x-mobilepay-idempotency-key`` header has to be unique per request unless the request is a retry of a previous request <br> Refund of payment not possible when payment is not captured <br> Refund ``CurrencyCode`` is different than payment ``CurrencyCode`` <br> Payment is too old <br> Refund ``Amount`` is too high <br> Refund not possible due to insufficient funds on payment point |
 
 </details><br>
 

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -62,7 +62,8 @@ Once a payment is captured, the payment amount is immediately charged from the c
 longer be cancelled. Instead, the payment amount can be transferred back to the customer, by performing *refunds*. 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
 the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
-A refund can only be made if there is sufficient funds on the payment point (wallet).
+
+A refund can be executed if the Merchants payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail.
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -63,7 +63,7 @@ longer be cancelled. Instead, the payment amount can be transferred back to the 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
 the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
 
-A refund can be executed if the store payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail.
+A refund can be executed if the store payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail with errorcode 1368
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -63,7 +63,7 @@ longer be cancelled. Instead, the payment amount can be transferred back to the 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
 the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
 
-A refund can be executed if the Merchants payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail.
+A refund can be executed if the store payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail.
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -63,7 +63,7 @@ longer be cancelled. Instead, the payment amount can be transferred back to the 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
 the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
 
-A refund can be executed if the store payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail with errorcode 1368
+A refund can be executed if the store payment balance contains enough money to cover the refund. If the balance doesn’t cover the amount of the refund, the refund will fail with error code 1368
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -61,7 +61,8 @@ It is required of the client to implement a periodically scheduled job of runnin
 Once a payment is captured, the payment amount is immediately charged from the customer. Therefore, the payment can no
 longer be cancelled. Instead, the payment amount can be transferred back to the customer, by performing *refunds*. 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
-the captured payment amount. A payment can be refunded up to 30 days after the payment was captured. After 30 days a refund is no longer possible with MobilePay.
+the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
+A refund can only be made if there is sufficient funds on the payment point.
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/payment_flows.md
+++ b/docs/payment_flows.md
@@ -62,7 +62,7 @@ Once a payment is captured, the payment amount is immediately charged from the c
 longer be cancelled. Instead, the payment amount can be transferred back to the customer, by performing *refunds*. 
 Each captured payment can be refunded multiple times with the restriction that the sum of the refunds cannot exceed
 the captured payment amount. A payment can be refunded up to 90 days after the payment was captured. After 90 days a refund is no longer possible with MobilePay.
-A refund can only be made if there is sufficient funds on the payment point.
+A refund can only be made if there is sufficient funds on the payment point (wallet).
 
 The sequence diagram below shows a sunshine scenario for a refund. Initiating a refund yields a ``refundId`` that can be
 used to capture the refund. A refund starts out in the *Initiated* state and transitions to the *Reserved*

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,9 @@
 The Point of Sale API V10 is now in production.
 
 ## Changelog
+### 2022-08-12
+- Introduced error code 1368 to [API Errors](endpoint_errors.md)
+
 ### 2022-07-28
 - Introduced error code 1204 to [API Errors](endpoint_errors.md)
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@ The Point of Sale API V10 is now in production.
 
 ## Changelog
 ### 2022-08-12
-- Introduced error code 1368 to [API Errors](endpoint_errors.md) and added description on refundflow in [Payment flow](payment_flows)
+- Introduced error code 1368 to [API Errors](endpoint_errors.md) and edited description on refundflow in [Refund Flow](payment_flows#refunds)
 
 ### 2022-07-28
 - Introduced error code 1204 to [API Errors](endpoint_errors.md)

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@ The Point of Sale API V10 is now in production.
 
 ## Changelog
 ### 2022-08-12
-- Introduced error code 1368 to [API Errors](endpoint_errors.md)
+- Introduced error code 1368 to [API Errors](endpoint_errors.md) and added description on refundflow in [Payment flow](payment_flows)
 
 ### 2022-07-28
 - Introduced error code 1204 to [API Errors](endpoint_errors.md)


### PR DESCRIPTION
Added new errorcode to Refund. When a PaymentPoint does not have the sufficient funds to create a refund, we will return 409 statuscode instead of 500. 

Extended Refund flow description 